### PR TITLE
NuGet changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,8 @@ Refer [lazy action setup](https://github.com/variant-inc/lazy-action-setup/blob/
         ecr_repository: naveen-demo-app/demo-repo
         nuget_push_enabled: 'true'
         sonar_scan_in_docker: 'false'
-        nuget_src_project: "src/Variant.ScheduleAdherence.Client/Variant.ScheduleAdherence.Client.csproj"
-        nuget_package_name: 'demo-app'
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        nuget_push_token: ${{ secrets.GITHUB_TOKEN }}
+        nuget_pull_token: ${{ secrets.PKG_READ }}
 
 ```
 
@@ -125,9 +124,8 @@ jobs:
         ecr_repository: naveen-demo-app/demo-repo
         nuget_push_enabled: 'true'
         sonar_scan_in_docker: 'false'
-        nuget_src_project: "src/Variant.ScheduleAdherence.Client/Variant.ScheduleAdherence.Client.csproj"
-        nuget_package_name: 'demo-app'
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        nuget_push_token: ${{ secrets.GITHUB_TOKEN }}
+        nuget_pull_token: ${{ secrets.PKG_READ }}
 
     - name: Lazy Action Octopus
       uses: variant-inc/lazy-action-octopus@v1
@@ -150,6 +148,5 @@ jobs:
 | `sonar_scan_in_docker`        | "false"         | Is sonar scan running as part of Dockerfile                                                                                  | false    |
 | `sonar_scan_in_docker_target` | "sonarscan-env" | sonar scan in docker target.                                                                                                 | false    |
 | `nuget_push_enabled`          | "false"         | Enabled Nuget Push to Package Registry.                                                                                      | false    |
-| `nuget_package_name`          |                 | Creates the nuget package with this name. Used only when nuget_push_enabled is true.                                         | false    |
-| `nuget_project_path`           |                 | Path to the Nuget Project File (.csproj). Used only when nuget_push_enabled is true. Required if nuget_push_enabled is true. | false    |
-| `github_token`                |                 | Github Token                                                                                                                 | true     |
+| `nuget_pull_token`            |                 | GitHub token with repo read permissions for pulling NuGet packages Token                                                     | true     |
+| `nuget_push_token`            |                 | GitHub token with package write permissions for pushing NuGet packages Token                                                 | false    |

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,6 @@ inputs:
 
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:sha-f89e2903df9f056356c9018c99af7774025624da
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v0.1.3
   env:
     GITHUB_TOKEN: ${{ inputs.nuget_pull_token }}

--- a/action.yml
+++ b/action.yml
@@ -34,13 +34,16 @@ inputs:
     description: "Enable Build and Push Container Image"
     required: false
     default: "true"
-  github_token:
-    description: "Github token"
+  nuget_pull_token:
+    description: "GitHub token with repo read permissions for pulling NuGet packages"
     required: true
+  nuget_push_token:
+    description: "GitHub token with package write permissions for pushing NuGet packages"
+    required: false
 
 
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v0.1.2
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:sha-8b736442008b03493d5fd14f0495eaca615babf5
   env:
-    GITHUB_TOKEN: ${{ inputs.github_token }}
+    GITHUB_TOKEN: ${{ inputs.nuget_pull_token }}

--- a/action.yml
+++ b/action.yml
@@ -24,12 +24,6 @@ inputs:
     description: "Enabled Nuget Push to Package Registry."
     required: false
     default: "false"
-  nuget_package_name:
-    description: "Creates the nuget package with this name.Used only when nuget_push_enabled is true."
-    required: false
-  nuget_project_path:
-    description: "Path to the Nuget Project File (.csproj).Used only when nuget_push_enabled is true.Required if nuget_push_enabled is true."
-    required: false
   container_push_enabled:
     description: "Enable Build and Push Container Image"
     required: false
@@ -44,6 +38,6 @@ inputs:
 
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:sha-8b736442008b03493d5fd14f0495eaca615babf5
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:sha-f89e2903df9f056356c9018c99af7774025624da
   env:
     GITHUB_TOKEN: ${{ inputs.nuget_pull_token }}

--- a/scripts/nuget_push.sh
+++ b/scripts/nuget_push.sh
@@ -2,19 +2,11 @@
 
 set -eu
 
-: "$INPUT_NUGET_PROJECT_PATH"
-
 cd "$GITHUB_WORKSPACE"
 
 mkdir -p out
 
-
-if [ -n "$INPUT_NUGET_PACKAGE_NAME" ]; then
-  echo "Taking nuget pacakge name"
-  dotnet pack "$INPUT_NUGET_PROJECT_PATH" --no-restore -c Release --version-suffix "$IMAGE_VERSION" -o /out -p:PackageID="$INPUT_NUGET_PACKAGE_NAME"
-else
-  dotnet pack "$INPUT_NUGET_PROJECT_PATH" --no-restore -c Release --version-suffix "$IMAGE_VERSION" -o /out
-fi
-dotnet nuget push "/out/**/*.nupkg" --source github --skip-duplicate --api-key "$GITHUB_TOKEN"
+dotnet pack --no-restore -c Release --version-suffix "$IMAGE_VERSION" -o /out
+dotnet nuget push "/out/**/*.nupkg" --source github --skip-duplicate --api-key "$INPUT_NUGET_PUSH_TOKEN"
 
 rm -rf out


### PR DESCRIPTION
# Summary
- This allows us to keep our `NuGet.config` files the same
- All packable solution projects will be packed instead of requiring a specific `nuget_package_name` and `nuget_package_path`
- Workflow changes in schedule-adherence can be seen [here](https://github.com/variant-inc/schedule-adherence/blob/f/LazyDeploys/.github/workflows/branch-build.yaml)
  - No other code changes were required, [proof](https://github.com/variant-inc/schedule-adherence/compare/f/LazyDeploys?expand=1)

# Results
- Successful build [here](https://github.com/variant-inc/schedule-adherence/runs/1921625735?check_suite_focus=true)
- Successful [_pull_](https://github.com/variant-inc/schedule-adherence/runs/1921625735?check_suite_focus=true#step:5:846) of an internal package (Variant.Here.Client via `dotnet restore`)
- Successful [_push_](https://github.com/variant-inc/schedule-adherence/runs/1921625735?check_suite_focus=true#step:5:1066) of a package (Variant.ScheduleAdherence.Client)
  - Please excuse the error `already been pushed`, this is because I re-ran the build

# Issues
- Versions are a little funky
  - [Docker images](https://github.com/variant-inc/schedule-adherence/runs/1921625735?check_suite_focus=true#step:5:1025)
  - [NuGet packages](https://github.com/variant-inc/schedule-adherence/runs/1921625735?check_suite_focus=true#step:5:1062)
- It looks like we set version variables in lazy-action-setup [here](https://github.com/variant-inc/lazy-action-setup/blob/master/action.yml#L15-L17) using GitVersion, I chose not to make changes there since this "setup" action might be used by other teams