### PR TITLE
Add different versions of dotnet

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git/
+.github/

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,14 +13,14 @@ Please delete options that are not relevant.
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update
 
-# How Has This Been Tested?
+## How Has This Been Tested?
 
 Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
 
 - [ ] Unit Tests
 - [ ] Sanity Testing
 
-# Checklist:
+## Checklist
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -30,7 +30,7 @@ jobs:
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
           ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
         run: |
-          docker build \
+          docker buildx build \
             --build-arg BUILD_DATE \
             --build-arg BUILD_REVISION=$GITHUB_SHA \
             --build-arg BUILD_VERSION=$GITHUB_SHA \

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,10 +1,4 @@
 ---
-#########################
-#########################
-## Deploy Branch Docker Image to ECR ##
-#########################
-#########################
-
 name: Branch dotnet image push to ECR
 on:
   push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,14 @@ RUN apk add --no-cache \
   \
   dotnet tool install dotnet-sonarscanner --tool-path /usr/local/bin &&\
   dotnet tool install coverlet.console --version 1.7.2 --tool-path /usr/local/bin &&\
-  dotnet tool install dotnet-reportgenerator-globaltool --tool-path /usr/local/bin
+  dotnet tool install dotnet-reportgenerator-globaltool --tool-path /usr/local/bin &&\
+  curl -fsSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh &&\
+  chmod +x dotnet-install.sh &&\
+  ./dotnet-install.sh --channel Current &&\
+  ./dotnet-install.sh --channel LTS &&\
+  ./dotnet-install.sh --channel 5.0 &&\
+  ./dotnet-install.sh --channel 3.1 &&\
+  ln -sf /root/.dotnet/dotnet /usr/bin/dotnet
 
 COPY . /
 RUN chmod +x -R /scripts/* /*.sh

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Refer [lazy action setup](https://github.com/variant-inc/lazy-action-setup/blob/
 
     - name: Lazy action steps
       id: lazy-action
-      uses: variant-inc/lazy-action-dotnet@v0.1.0
+      uses: variant-inc/lazy-action-dotnet@v0.1.4
       env:
         NUGET_TOKEN: ${{ secrets.PKG_READ }}
         AWS_DEFAULT_REGION: us-east-2
@@ -140,13 +140,13 @@ jobs:
 
 ### Input Parameters
 
-| Parameter                     | Default         | Description                                                                                                                  | Required |
-| ----------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `src_file_dir_path`           | `.`             | Directory path to the solution file                                                                                          | true     |
-| `dockerfile_dir_path`         | `.`             | Directory path to the dockerfile                                                                                             | true     |
-| `ecr_repository`              |                 | ECR Repository name                                                                                                          | true     |
-| `sonar_scan_in_docker`        | "false"         | Is sonar scan running as part of Dockerfile                                                                                  | false    |
-| `sonar_scan_in_docker_target` | "sonarscan-env" | sonar scan in docker target.                                                                                                 | false    |
-| `nuget_push_enabled`          | "false"         | Enabled Nuget Push to Package Registry.                                                                                      | false    |
-| `nuget_pull_token`            |                 | GitHub token with repo read permissions for pulling NuGet packages Token                                                     | true     |
-| `nuget_push_token`            |                 | GitHub token with package write permissions for pushing NuGet packages Token                                                 | false    |
+| Parameter                     | Default         | Description                                                                  | Required |
+| ----------------------------- | --------------- | ---------------------------------------------------------------------------- | -------- |
+| `src_file_dir_path`           | `.`             | Directory path to the solution file                                          | true     |
+| `dockerfile_dir_path`         | `.`             | Directory path to the dockerfile                                             | true     |
+| `ecr_repository`              |                 | ECR Repository name                                                          | true     |
+| `sonar_scan_in_docker`        | "false"         | Is sonar scan running as part of Dockerfile                                  | false    |
+| `sonar_scan_in_docker_target` | "sonarscan-env" | sonar scan in docker target.                                                 | false    |
+| `nuget_push_enabled`          | "false"         | Enabled Nuget Push to Package Registry.                                      | false    |
+| `nuget_pull_token`            |                 | GitHub token with repo read permissions for pulling NuGet packages Token     | true     |
+| `nuget_push_token`            |                 | GitHub token with package write permissions for pushing NuGet packages Token | false    |

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,6 @@ inputs:
 
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v0.1.3
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:sha-a11581595a58c13d547aabc718968521f6ec7f4b
   env:
     GITHUB_TOKEN: ${{ inputs.nuget_pull_token }}

--- a/action.yml
+++ b/action.yml
@@ -35,9 +35,8 @@ inputs:
     description: "GitHub token with package write permissions for pushing NuGet packages"
     required: false
 
-
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:sha-a11581595a58c13d547aabc718968521f6ec7f4b
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v0.1.4
   env:
     GITHUB_TOKEN: ${{ inputs.nuget_pull_token }}


### PR DESCRIPTION
# Description

Added different versions of `dotnet` to allow users to choose which `dotnet` to use.
Reference: https://docs.microsoft.com/en-us/dotnet/core/versions/selection

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested it using Journey's API repository.
Successful build here: https://github.com/variant-inc/journeys/runs/1935244600?check_suite_focus=true

- [ ] Unit Tests
- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] New and existing unit tests pass locally with my changes~~
- [x] Any dependent changes have been merged and published in downstream modules
